### PR TITLE
Add force parameter to spawnParticle to display particles regardless of distance

### DIFF
--- a/worldedit-sui/src/main/java/eu/kennytv/worldeditsui/util/ParticleHelper.java
+++ b/worldedit-sui/src/main/java/eu/kennytv/worldeditsui/util/ParticleHelper.java
@@ -21,40 +21,57 @@ package eu.kennytv.worldeditsui.util;
 import eu.kennytv.worldeditsui.Settings;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Particle;
 import org.bukkit.entity.Player;
 
 public final class ParticleHelper {
 
     private final Settings settings;
+    private boolean hasForceParameter = false;
 
     public ParticleHelper(final Settings settings) {
         this.settings = settings;
+        this.hasForceParameter = checkMethodAvailability();
     }
 
     public void playEffect(final ParticleData particle, final Location location, final Player player) {
         if (!location.getWorld().equals(player.getWorld())) return;
 
         if (player.getLocation().distanceSquared(location) > particle.radiusSquared()) return;
-
-        player.spawnParticle(particle.getParticle(), location, 1,
-                particle.offX(), particle.offY(), particle.offZ(), particle.speed(), particle.getData(), true);
+        if (hasForceParameter) {
+            player.spawnParticle(particle.getParticle(), location, 1, particle.offX(), particle.offY(), particle.offZ(), particle.speed(), particle.getData(), true);
+        } else {
+            player.spawnParticle(particle.getParticle(), location, 1, particle.offX(), particle.offY(), particle.offZ(), particle.speed());
+        }
     }
 
     public void playEffectToAll(final ParticleData particle, final ParticleData othersParticle, final Location location, final Player origin) {
         for (final Player player : Bukkit.getOnlinePlayers()) {
-            if (!location.getWorld().equals(player.getWorld())
-                    || player.getLocation().distanceSquared(location) > particle.radiusSquared()) continue;
+            if (!location.getWorld().equals(player.getWorld()) || player.getLocation().distanceSquared(location) > particle.radiusSquared()) continue;
 
             final boolean originalPlayer = player.getUniqueId().equals(origin.getUniqueId());
             if (!originalPlayer && !canSeeOtherParticles(player)) continue;
 
             final ParticleData toSend = originalPlayer ? particle : othersParticle;
-            player.spawnParticle(toSend.getParticle(), location, 1,
-                    particle.offX(), particle.offY(), particle.offZ(), particle.speed(), toSend.getData(), true);
+            if (hasForceParameter) {
+                player.spawnParticle(toSend.getParticle(), location, 1, particle.offX(), particle.offY(), particle.offZ(), particle.speed(), toSend.getData(), true);
+            } else {
+                player.spawnParticle(toSend.getParticle(), location, 1, particle.offX(), particle.offY(), particle.offZ(), particle.speed(), toSend.getData());
+            }
         }
     }
 
     private boolean canSeeOtherParticles(final Player player) {
         return settings.getOtherParticlesPermission() == null || player.hasPermission(settings.getOtherParticlesPermission());
+    }
+
+    public boolean checkMethodAvailability() {
+        try {
+            Player.class.getMethod("spawnParticle", Particle.class, double.class, double.class, double.class, int.class, double.class, double.class, double.class, double.class, Object.class, boolean.class);
+
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
     }
 }

--- a/worldedit-sui/src/main/java/eu/kennytv/worldeditsui/util/ParticleHelper.java
+++ b/worldedit-sui/src/main/java/eu/kennytv/worldeditsui/util/ParticleHelper.java
@@ -37,7 +37,7 @@ public final class ParticleHelper {
         if (player.getLocation().distanceSquared(location) > particle.radiusSquared()) return;
 
         player.spawnParticle(particle.getParticle(), location, 1,
-                particle.offX(), particle.offY(), particle.offZ(), particle.speed(), particle.getData());
+                particle.offX(), particle.offY(), particle.offZ(), particle.speed(), particle.getData(), true);
     }
 
     public void playEffectToAll(final ParticleData particle, final ParticleData othersParticle, final Location location, final Player origin) {
@@ -50,7 +50,7 @@ public final class ParticleHelper {
 
             final ParticleData toSend = originalPlayer ? particle : othersParticle;
             player.spawnParticle(toSend.getParticle(), location, 1,
-                    particle.offX(), particle.offY(), particle.offZ(), particle.speed(), toSend.getData());
+                    particle.offX(), particle.offY(), particle.offZ(), particle.speed(), toSend.getData(), true);
         }
     }
 


### PR DESCRIPTION
## Description
This modification adds the `force=true` parameter to the `spawnParticle` method calls in the `ParticleHelper` class.

## Problem Solved
The `particle-viewdistance` parameter in the configuration doesn't work as expected for some use cases. Even with a high value, particles are not always visible at long distances.

## Solution
Use of the `force` parameter in Bukkit's `spawnParticle` method which allows forcing particles to be sent to the client regardless of distance.

## Tests Performed
- Tested on Purpur 1.21.4

- Verified that particles are visible at distances over 100 blocks
![2025-05-18_13 37 59](https://github.com/user-attachments/assets/7b73dcf4-b4a0-4928-b22d-40215db8aeed)
![2025-05-18_13 40 57](https://github.com/user-attachments/assets/5cdfdf43-8f3d-406e-881a-b1124921f088)
- No notable impact on performance